### PR TITLE
Bump @enonic-types/* to ^8.0.0-B4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,10 @@
       "name": "lib-asset",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@enonic-types/core": "^7.16.3",
-        "@enonic-types/global": "^7.16.3",
-        "@enonic-types/lib-io": "^7.16.3",
-        "@enonic-types/lib-portal": "^7.16.3",
+        "@enonic-types/core": "^8.0.0-B4",
+        "@enonic-types/global": "^8.0.0-B4",
+        "@enonic-types/lib-io": "^8.0.0-B4",
+        "@enonic-types/lib-portal": "^8.0.0-B4",
         "@enonic/eslint-config": "^2.3.0",
         "@eslint/js": "^10.0.1",
         "@item-enonic-types/lib-router": "^3.1.0",
@@ -586,40 +586,36 @@
       }
     },
     "node_modules/@enonic-types/core": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-7.16.3.tgz",
-      "integrity": "sha512-0TbkNHMO9xir/m92RavXL6XIM4L4zA5J4Tk1ettODrX+3YfcoFAXiGlPQanD0k4o3s79D0ZYPw2QKPhA2/OAdw==",
-      "dev": true,
-      "license": "Apache-2.0"
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-8.0.0-B4.tgz",
+      "integrity": "sha512-UGq6ixxLMOEQm5NYdjilWUIXugcGiEKAmzuzM1vBCltdJLJfqgJYjVgrziXhbiulpYdxcMoDTe0N8uF7R6j25w==",
+      "dev": true
     },
     "node_modules/@enonic-types/global": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@enonic-types/global/-/global-7.16.3.tgz",
-      "integrity": "sha512-dEMj48NHDSXVBK4c7eRZAGoh/3xM42Sbf0ZmsnQqxpB69SBfht5m6hXR/weHbnj1mhYPyjWCyB56R3Uhy7NLFg==",
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/global/-/global-8.0.0-B4.tgz",
+      "integrity": "sha512-CC7OQvPOtxMBfOhnLcDYaMxfdSIaYkbDQ8WnDmXPEPDHMNkraZhirLpdvAnS/7PObS/yEuS94x9GEAqmEd+YFQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@enonic-types/core": "7.16.3"
+        "@enonic-types/core": "8.0.0-B4"
       }
     },
     "node_modules/@enonic-types/lib-io": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@enonic-types/lib-io/-/lib-io-7.16.3.tgz",
-      "integrity": "sha512-yLAt8ZjKdecgwSTMTqigCs3gZ6g2ZjJdW/2TonQlMZPbR2qZ0KdMHK+iSksIBajNADzhw0ntM1f+fHq5qlYPDQ==",
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/lib-io/-/lib-io-8.0.0-B4.tgz",
+      "integrity": "sha512-v6FDKyGDogaGqpvalN3jow/dJ63BY2G9SjyBHxflV5T2M5fWOWu29/kMObrd0ebwvIwmc0yLPGqSE0jky1+qmg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@enonic-types/core": "7.16.3"
+        "@enonic-types/core": "8.0.0-B4"
       }
     },
     "node_modules/@enonic-types/lib-portal": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@enonic-types/lib-portal/-/lib-portal-7.16.3.tgz",
-      "integrity": "sha512-B2bCKGIqDXzGa9tb5uZNNauF6Yf4Ie2qtvqjykzgzJq4B8NKlNr5we7gSZZnB5svBrx0jtqlnMBjtdM92JU7XA==",
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/lib-portal/-/lib-portal-8.0.0-B4.tgz",
+      "integrity": "sha512-QBs9yjIMyLIurd5KiO6q37lxFEhjlsJo5qmgPk0xk3OeDqbI47rQlJnrqUVR/3z5bvbE2Dx6b+RkRp4r2E7Pbg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@enonic-types/core": "7.16.3"
+        "@enonic-types/core": "8.0.0-B4"
       }
     },
     "node_modules/@enonic/eslint-config": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   },
   "description": "Enonic XP library for serving assets from a folder in the application resource structure",
   "devDependencies": {
-    "@enonic-types/core": "^7.16.3",
-    "@enonic-types/global": "^7.16.3",
-    "@enonic-types/lib-io": "^7.16.3",
-    "@enonic-types/lib-portal": "^7.16.3",
+    "@enonic-types/core": "^8.0.0-B4",
+    "@enonic-types/global": "^8.0.0-B4",
+    "@enonic-types/lib-io": "^8.0.0-B4",
+    "@enonic-types/lib-portal": "^8.0.0-B4",
     "@enonic/eslint-config": "^2.3.0",
     "@eslint/js": "^10.0.1",
     "@item-enonic-types/lib-router": "^3.1.0",
@@ -25,6 +25,11 @@
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.2"
+  },
+  "overrides": {
+    "@item-enonic-types/lib-router": {
+      "@enonic-types/core": "^8.0.0-B4"
+    }
   },
   "homepage": "https://github.com/enonic/lib-asset#readme",
   "name": "lib-asset",


### PR DESCRIPTION
## Summary
- Bump all `@enonic-types/*` devDependencies (`core`, `global`, `lib-io`, `lib-portal`) from `^7.16.3` to `^8.0.0-B4` to align with XP 8.
- Add an npm `overrides` block that forces `@item-enonic-types/lib-router` (which still pins `@enonic-types/core` to `^7.x`) to resolve to the XP 8 core type. Without this override, the router's nested XP 7 `Request`/`Response` types collide with the XP 8 versions at the `router.get` boundary (e.g. XP 8 `Request` adds a required `locales` field).
- Lockfile refreshed.

The library's own published type package (`@enonic-types/lib-asset`, ^1.x in consumers) is untouched — only consumer deps were updated, per task instructions. The emitted `build/types/package.json` correctly tracks the XP 8 alignment via the existing `gradle.properties` `xpVersion` placeholder.

## Test plan
- [x] `npm run check` (types + lint) — green
- [x] `npm run build` — `build:server` (tsup) and `build:types` (tsc + bun process) both green; emitted `.d.ts` files compile against XP 8
- [x] `bun test` — 25/25 pass

Reference: enonic/doc-code@967803a (XP7→XP8 `@enonic-types` upgrade note for apps and libraries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)