### PR TITLE
Drop lib-router dependency #558

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,6 @@ dependencies {
   compileOnly xplibs.api.script
   compileOnly xplibs.api.admin
 
-  implementation libs.lib.router
-
   testImplementation platform( libs.mockito.core )
   testImplementation libs.junit.jupiter
   testImplementation libs.mockito.jupiter

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,6 @@ junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 mockito-core = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
 mockito-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 
-lib-router = { module = "com.enonic.lib:lib-router", version = "4.0.0" }
-
 [plugins]
 enonic-defaults = { id = "com.enonic.defaults", version.ref = "enonicDefaults" }
 node-gradle = { id = "com.github.node-gradle.node", version.ref = "nodeGradle" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@enonic-types/lib-portal": "^8.0.2",
         "@enonic/eslint-config": "^2.3.0",
         "@eslint/js": "^10.0.1",
-        "@item-enonic-types/lib-router": "^3.1.0",
         "@jest/globals": "^30.4.1",
         "@swc/core": "^1.15.43",
         "@types/bun": "^1.3.14",
@@ -1396,16 +1395,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@item-enonic-types/lib-router": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@item-enonic-types/lib-router/-/lib-router-3.1.0.tgz",
-      "integrity": "sha512-gNp1WNV62eyQAgn7XtcuHQBabyN7BO2vJD0gP3kvchDvJcyriNtzE3U5yETCOexqKGHFurt9+oLPE3aHn2jDyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@enonic-types/core": "^7.15.0"
-      }
-    },
     "node_modules/@jest/diff-sequences": {
       "version": "30.4.0",
       "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
@@ -2362,9 +2351,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2382,9 +2368,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2402,9 +2385,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2422,9 +2402,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2442,9 +2419,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2462,9 +2436,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2703,175 +2674,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
-      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.62.0",
-        "@typescript-eslint/types": "^8.62.0",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
-      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/visitor-keys": "8.62.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
-      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
-      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
-      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.62.0",
-        "@typescript-eslint/tsconfig-utils": "8.62.0",
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/visitor-keys": "8.62.0",
-        "debug": "^4.4.3",
-        "minimatch": "^10.2.2",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
-      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.62.0",
-        "eslint-visitor-keys": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
@@ -5937,31 +5739,6 @@
         "@typescript-eslint/parser": "8.62.0",
         "@typescript-eslint/typescript-estree": "8.62.0",
         "@typescript-eslint/utils": "8.62.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
-      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
-        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@enonic-types/lib-portal": "^8.0.2",
     "@enonic/eslint-config": "^2.3.0",
     "@eslint/js": "^10.0.1",
-    "@item-enonic-types/lib-router": "^3.1.0",
     "@jest/globals": "^30.4.1",
     "@swc/core": "^1.15.43",
     "@types/bun": "^1.3.14",
@@ -25,11 +24,6 @@
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.62.0"
-  },
-  "overrides": {
-    "@item-enonic-types/lib-router": {
-      "@enonic-types/core": "^8.0.1"
-    }
   },
   "homepage": "https://github.com/enonic/lib-asset#readme",
   "name": "lib-asset",

--- a/src/main/resources/apis/asset/asset.ts
+++ b/src/main/resources/apis/asset/asset.ts
@@ -1,14 +1,11 @@
 import type {Request, Response} from '@enonic-types/core';
 
-import Router from '/lib/router';
 import {requestHandler} from './requestHandler';
 
-const router = Router();
-
-router.get('{path:.*}', (request: Request): Response => {
-  return requestHandler({request});
-});
-
 export const all = (request: Request): Response => {
-  return router.dispatch(request);
+  const method = (request.method || '').toUpperCase();
+  if (method === 'GET' || method === 'HEAD') {
+    return requestHandler({request});
+  }
+  return {status: 404};
 }

--- a/src/main/resources/tsconfig.json
+++ b/src/main/resources/tsconfig.json
@@ -4,7 +4,6 @@
       "ES2015", // String.prototype.endsWith // TODO Check that this works in Nashorn
     ],
     "paths": {
-      "/lib/router": ["../../../node_modules/@item-enonic-types/lib-router"],
       "/lib/xp/*": ["../../../node_modules/@enonic-types/lib-*"],
       // "/*": ["./*"], // bun doesn't resolve these?
     },

--- a/tsup/server.ts
+++ b/tsup/server.ts
@@ -52,7 +52,6 @@ export default function buildServerConfig(): Options {
       '/lib/http-client',
       '/lib/license',
       '/lib/mustache',
-      '/lib/router',
       '/lib/util',
       '/lib/vanilla',
       '/lib/text-encoding',


### PR DESCRIPTION
## Summary

`lib-asset` is a foundational library that shouldn't depend on another essential library (`lib-router`). The only use of lib-router was a single catch-all `{path:.*}` GET route dispatched via `router.dispatch()`. This PR replaces that with a plain method-check inline in `apis/asset/asset.ts` — forwarding GET/HEAD to `requestHandler` and returning 404 for other methods (the exact behavior of the previous router setup, which registered no non-GET routes).

## Changes

- `src/main/resources/apis/asset/asset.ts` — remove `/lib/router` import; inline a small method-dispatch that calls `requestHandler` for GET/HEAD and returns `{status: 404}` otherwise.
- `build.gradle` — drop `implementation libs.lib.router`.
- `gradle/libs.versions.toml` — drop the `lib-router` catalog entry.
- `src/main/resources/tsconfig.json` — drop `/lib/router` path mapping.
- `tsup/server.ts` — drop `/lib/router` from the externals list.
- `package.json` / `package-lock.json` — drop `@item-enonic-types/lib-router` devDependency + override.

## Behavior notes

- `requestHandler` never read `req.pathParams`, so the router-set `pathParams.path` was never consumed — no need to preserve it.
- The old code's `router.dispatch()` returned `{status: 404}` for any non-GET method (HEAD fell through to GET via the router's internal fallback). The new code preserves that.

## Verify

- `./gradlew clean build` — BUILD SUCCESSFUL. Unit tests (Java) + bun feature tests (25 pass, 0 fail) + typecheck + eslint all green.
- `./gradlew dependencies` — no `lib-router` anywhere on any classpath.
- Built jar (`build/libs/lib-asset-*.jar`) contains no `require("/lib/router")` — verified by inspecting the bundled `apis/asset/asset.js`.

## Test plan

- [x] `./gradlew clean build` passes locally
- [x] `bun test` — 25 pass, 0 fail
- [x] No `lib.router` / `lib-router` / `/lib/router` references anywhere outside `build/` and `node_modules/`
- [x] Built jar has no lib-router `require`

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)