### PR TITLE
Align docs to lib-cors layout #562

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "2.x"
       - "1.x"
     paths:
       - 'docs/**'

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -3,6 +3,8 @@
 
 == Introduction
 
+NOTE: Versions 2.x target XP 8+.
+
 A simple solution to serving static assets for your Enonic application. Generates unique fingerprint URLs and sets immutable cache headers for CDN/edge and client caching. Create URLs to your assets with bundled `assetUrl` function.
 
 TIP: To host a static webapp, or for more fine-grained control over static assets, check out link:https://developer.enonic.com/docs/lib-static/stable[lib-static] instead.
@@ -220,7 +222,7 @@ const url = assetUrl({
 
 == Migrating from lib-portal
 
-Lib-asset replaces the asset hosting feature that has been part of XP core. As of XP 7.15, this feature will be deprecated, and developers should migrate to lib-asset (or lib-static) instead
+Lib-asset replaces the `portal.assetUrl` function that ships with XP core. The XP-core version is deprecated; migrate to lib-asset (or lib-static) instead.
 
 Follow the steps below to migrate from the native asset handling to lib-asset.
 

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -2,12 +2,12 @@
   "versions": [
     {
       "label": "stable",
-      "checkout": "1.x",
+      "checkout": "2.x",
       "latest": true
     },
     {
-      "label": "next",
-      "checkout": "master"
+      "label": "1.x",
+      "checkout": "1.x"
     }
   ]
 }


### PR DESCRIPTION
Aligns the `docs/` layout with the reference in [enonic/lib-cors](https://github.com/enonic/lib-cors) and drops pre-XP-8 changelog phrasing from the current docs.

## Changes

- `docs/index.adoc`: added `NOTE: Versions 2.x target XP 8+.` near the top, and rewrote the "Migrating from lib-portal" intro to drop the `As of XP 7.15, this feature will be deprecated` phrasing — under XP 8, `portal.assetUrl` is already deprecated.
- `docs/versions.json`: `stable` now points at `2.x` (was `1.x`), and the second entry is `1.x` (was the transient `next → master`).
- `.github/workflows/enonic-docgen.yml`: added `2.x` to `on.push.branches` so the docgen workflow also runs on the stable branch (matching the layout on `lib-cors`).

## Not touched

- The XP 7 line's `1.x` branch is left alone.
- The rest of the docs already read as current documentation — no other "added in vX.Y" / "since X.Y" / "introduced in X" annotations were found in `docs/index.adoc`.

Closes #562